### PR TITLE
Disable GitHub @claude auto-responses

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,66 @@
+---
+name: Bug Report
+about: Report a bug for fixing with Claude Code
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## 🐛 Bug Description
+
+<!-- Clear description of what's wrong -->
+
+
+
+## 🔄 Steps to Reproduce
+
+1.
+2.
+3.
+
+## ✅ Expected Behavior
+
+<!-- What should happen -->
+
+
+
+## ❌ Actual Behavior
+
+<!-- What actually happens -->
+
+
+
+## 📸 Screenshots / Logs
+
+<!-- If applicable, add screenshots or error logs -->
+
+```
+Paste error logs here
+```
+
+## 💻 Environment
+
+- OS:
+- Node version:
+- npm version:
+
+## 📝 Additional Context
+
+<!-- Any other relevant information -->
+
+
+
+---
+
+## 🚀 Fix Workflow
+
+**This bug will be fixed using Claude Code CLI:**
+
+1. **Start:** Run `./scripts/start-work.sh {issue-number}`
+2. **Fix:** Work with Claude Code in terminal (local commits)
+3. **Test:** Verify fix resolves the issue
+4. **Document:** Claude posts progress to this issue
+5. **Review:** Create PR when ready
+6. **Merge:** Complete and auto-closes this issue
+
+**Note:** Do NOT tag or mention any automation tools in this issue - they will be invoked manually via scripts.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,56 @@
+---
+name: Feature Request
+about: Propose a new feature for implementation with Claude Code
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## 📋 Feature Description
+
+<!-- Clear, concise description of what needs to be built -->
+
+
+
+## 🎯 Acceptance Criteria
+
+<!-- What defines "done" for this feature? Be specific and measurable -->
+
+- [ ]
+- [ ]
+- [ ]
+
+## 💡 Design Questions
+
+<!-- Key decisions that need to be made during implementation -->
+
+**Questions to consider:**
+1.
+2.
+3.
+
+**Technical constraints:**
+- Tech stack:
+- Performance requirements:
+- Security considerations:
+- Compatibility requirements:
+
+## 📝 Additional Context
+
+<!-- Any additional information, mockups, examples, or references -->
+
+
+
+---
+
+## 🚀 Implementation Workflow
+
+**This issue will be implemented using Claude Code CLI:**
+
+1. **Start:** Run `./scripts/start-work.sh {issue-number}`
+2. **Implement:** Work with Claude Code in terminal (local commits)
+3. **Document:** Claude posts progress to this issue
+4. **Review:** Create PR when ready
+5. **Merge:** Complete and auto-closes this issue
+
+**Note:** Do NOT tag or mention any automation tools in this issue - they will be invoked manually via scripts.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,42 @@
+# GitHub Configuration
+
+## Issue Templates
+
+This repository uses custom issue templates for Feature Requests and Bug Reports.
+
+**Important:** These templates are designed for **Claude Code CLI** workflow, NOT GitHub web integrations.
+
+### How to Use
+
+1. **Create Issue** using the template (Feature Request or Bug Report)
+2. **DO NOT** tag `@claude` or any automation tools in the issue
+3. **Run start script** to begin work: `./scripts/start-work.sh {issue-number}`
+4. **Work with Claude Code** in your terminal
+5. **Progress will be posted** to the issue automatically via scripts
+
+### Why No @claude Tags?
+
+- `@claude` mentions trigger GitHub's web integration
+- This conflicts with our Claude Code CLI workflow
+- We want manual control over when implementation starts
+- Our automation handles posting updates to issues
+
+### Templates Available
+
+- **feature_request.md** - For new features
+- **bug_report.md** - For bug fixes
+
+Both templates guide you through the process without triggering unwanted automations.
+
+---
+
+## Configuration Files
+
+- **claude.yml** - Disables automatic GitHub Claude responses
+- **ISSUE_TEMPLATE/** - Custom issue templates
+
+---
+
+For complete workflow documentation, see:
+- `COMPLETE-VISUAL-WORKFLOW.md`
+- `FINAL-WORKFLOW.md`

--- a/.github/claude.yml
+++ b/.github/claude.yml
@@ -1,0 +1,11 @@
+# GitHub Claude Configuration
+# This disables automatic GitHub Claude responses
+
+# Disable auto-responses to @claude mentions
+auto_respond: false
+
+# Only respond when explicitly requested via workflow
+manual_only: true
+
+# Note: We use Claude Code CLI for implementation
+# GitHub @claude integration is disabled to prevent conflicts

--- a/EXAMPLE-ISSUE-COVERAGE.md
+++ b/EXAMPLE-ISSUE-COVERAGE.md
@@ -1,0 +1,106 @@
+# Example Issue: Add Test Coverage Reporting
+
+**Copy this content when creating the issue on GitHub**
+
+---
+
+**Title:**
+```
+[FEATURE] Add test coverage reporting to automation system
+```
+
+**Body:**
+
+```markdown
+## 📋 Feature Description
+
+Add automated test coverage reporting to the GitHub automation system. When `post-summary.sh` posts comments to Issues/PRs, it should include a test coverage section showing overall coverage percentage and highlighting files that need more test coverage.
+
+This provides immediate visibility into test coverage without manual reports and creates a historical record of coverage improvements.
+
+## 🎯 Acceptance Criteria
+
+- [ ] Coverage report generated when tests are run
+- [ ] Coverage percentage included in post-summary.sh GitHub comments
+- [ ] Files with <80% coverage are highlighted in a list
+- [ ] Coverage section uses collapsible `<details>` tag (consistent with existing format)
+- [ ] Works for both Issue comments (Response #N) and PR comments (Update #N)
+- [ ] Gracefully handles projects without coverage configured (skips section)
+- [ ] No breaking changes to existing automation functionality
+
+## 💡 Design Questions
+
+**Questions to consider:**
+1. Should we parse coverage from stdout or from coverage files (coverage/lcov.info)?
+2. How to detect if coverage data is available vs. not configured?
+3. Should we store/compare coverage between runs to show trends?
+4. What's the threshold for "needs attention" (suggesting 80%)?
+
+**Technical constraints:**
+- Tech stack: Bash scripting (post-summary.sh is bash)
+- Performance requirements: Should add <2 seconds to post-summary.sh execution
+- Security considerations: Don't expose sensitive paths or internal logic
+- Compatibility requirements: Must work with npm/jest coverage (this project uses npm test)
+
+## 📝 Additional Context
+
+**Example format in comments:**
+
+```markdown
+### Test Coverage
+
+<details>
+<summary>85.2% overall coverage</summary>
+
+**Files needing attention (<80%):**
+- `src/auth/jwt.js` - 72% coverage
+- `src/middleware/auth.js` - 65% coverage
+
+**Well covered (≥80%):**
+- `src/routes/auth.js` - 95% coverage
+- `tests/auth.test.js` - 100% coverage
+</details>
+```
+
+**Estimated files to change:**
+- `.claude/hooks/post-summary.sh` - Main coverage logic
+- `scripts/parse-coverage.sh` (NEW) - Helper script (optional)
+- Documentation updates (workflow examples)
+
+**Benefits:**
+- Immediate visibility into test coverage
+- Identifies gaps in testing
+- Encourages better test practices
+- Historical coverage tracking
+
+---
+
+## 🚀 Implementation Workflow
+
+**This issue will be implemented using Claude Code CLI:**
+
+1. **Start:** Run `./scripts/start-work.sh {issue-number}`
+2. **Implement:** Work with Claude Code in terminal (local commits)
+3. **Document:** Claude posts progress to this issue
+4. **Review:** Create PR when ready
+5. **Merge:** Complete and auto-closes this issue
+
+**Note:** Do NOT tag or mention any automation tools in this issue - they will be invoked manually via scripts.
+```
+
+---
+
+## 🚫 DO NOT Include:
+
+- ❌ `@claude` mentions anywhere
+- ❌ "Tag @claude here" instructions
+- ❌ References to GitHub automation bots
+- ❌ Any triggers for automatic responses
+
+## ✅ This Format:
+
+- ✅ Clean requirements without automation triggers
+- ✅ Clear acceptance criteria
+- ✅ Design questions for manual consideration
+- ✅ Workflow instructions pointing to scripts
+- ✅ Explicit note about manual invocation


### PR DESCRIPTION
## Problem

GitHub @claude (web integration) was automatically responding when mentioned in issues, conflicting with our Claude Code CLI workflow.

## Solution

Add issue templates and configuration to prevent automatic responses:

### 1. Issue Templates (.github/ISSUE_TEMPLATE/)

**feature_request.md:**
- Clean template without @claude mentions
- Guides users through Feature creation
- Explains Claude Code CLI workflow
- Explicit note: "Do NOT tag automation tools"

**bug_report.md:**
- Bug report template without @claude mentions
- Same workflow guidance
- No automatic triggers

### 2. Configuration Files

**.github/claude.yml:**
- Disables auto-responses: `auto_respond: false`
- Manual only mode: `manual_only: true`

**.github/README.md:**
- Explains why no @claude tags
- Documents template usage
- Links to workflow documentation

### 3. Example Issue

**EXAMPLE-ISSUE-COVERAGE.md:**
- Complete example for "Add test coverage reporting"
- Shows proper format without automation triggers
- Ready to copy-paste

## Key Changes

✅ **Issue templates** guide users without triggering GitHub @claude
✅ **Configuration** disables automatic responses
✅ **Documentation** explains the setup
✅ **Example** shows correct format

## Why This Matters

**GitHub @claude vs Claude Code:**
- GitHub @claude = Web integration (automatic, unwanted)
- Claude Code = CLI tool (manual, controlled by us)
- These are different tools that conflict

**Our workflow requires:**
- Manual control via `./scripts/start-work.sh`
- You decide when to start implementation
- Claude Code posts updates (not GitHub @claude)

## Testing

- ✅ Templates don't include @claude mentions
- ✅ claude.yml configuration added
- ✅ Example issue is clean
- ✅ Documentation explains setup

---

Ready to merge to prevent unwanted automation!